### PR TITLE
RCJ-42: Initialize route data for testing only

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -50,9 +50,13 @@ const List<Type> daos = [
 
 @DriftDatabase(tables: tables, daos: daos)
 class AppDatabase extends _$AppDatabase {
+  bool testMode = false;
+
   // we tell the database where to store the data with this constructor
   AppDatabase() : super(_openConnection());
-  AppDatabase.test(QueryExecutor executor) : super(executor);
+  AppDatabase.test(super.executor) {
+    testMode = true;
+  }
 
   @override
   int get schemaVersion => 1;
@@ -75,7 +79,7 @@ class AppDatabase extends _$AppDatabase {
         routeDifficultyDao.initializeData();
         routeStatusDao.initializeData();
 
-        if (kDebugMode) {
+        if (kDebugMode && !testMode) {
           loadTestData(this);
         }
       },

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -2,8 +2,10 @@ import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
+import 'package:redpoint/debug/load_test_data.dart';
 
 import 'models/climb_type/climb_type.dart';
 import 'models/climb_type/climb_type_to_grade_system.dart';
@@ -72,6 +74,10 @@ class AppDatabase extends _$AppDatabase {
         routeCompletedStatusDao.initializeData();
         routeDifficultyDao.initializeData();
         routeStatusDao.initializeData();
+
+        if (kDebugMode) {
+          loadTestData(this);
+        }
       },
     );
   }

--- a/lib/database/models/route/route.dart
+++ b/lib/database/models/route/route.dart
@@ -33,6 +33,10 @@ class RouteDao extends DatabaseAccessor<AppDatabase> with _$RouteDaoMixin {
   Future<List<RouteData>> get all => select(route).get();
   Stream<List<RouteData>> get watchAll => select(route).watch();
 
+  Future<int> insert(RouteCompanion entry) {
+    return into(route).insert(entry);
+  }
+
   Future<RouteData> insertReturning(RouteCompanion entry) {
     return into(route).insertReturning(entry);
   }

--- a/lib/database/models/tag/route_tag.dart
+++ b/lib/database/models/tag/route_tag.dart
@@ -20,7 +20,7 @@ class RouteTagDao extends DatabaseAccessor<AppDatabase> with _$RouteTagDaoMixin 
 
   Future<List<RouteTagData>> get all => select(routeTag).get();
 
-  Future<int> add(RouteTagCompanion entry) {
+  Future<int> insert(RouteTagCompanion entry) {
     return into(routeTag).insert(entry);
   }
 }

--- a/lib/database/models/tag/tag.dart
+++ b/lib/database/models/tag/tag.dart
@@ -14,6 +14,10 @@ class TagDao extends DatabaseAccessor<AppDatabase> with _$TagDaoMixin {
 
   Future<List<TagData>> get all => select(tag).get();
 
+  Future<int> insert(TagCompanion entry) {
+    return into(tag).insert(entry);
+  }
+
   Future<TagData> insertReturning(TagCompanion entry) {
     return into(tag).insertReturning(entry);
   }

--- a/lib/debug/load_test_data.dart
+++ b/lib/debug/load_test_data.dart
@@ -1,0 +1,17 @@
+import 'package:redpoint/database/database.dart';
+import 'package:redpoint/debug/test_data/routes.dart';
+import 'package:redpoint/debug/test_data/tags.dart';
+
+Future<void> loadTestData(AppDatabase driftDb) async {
+  for (var tag in testTags) {
+    await driftDb.tagDao.insert(tag);
+  }
+  var allTagIds = testTags.map((e) => e.id);
+  for (var route in testRoutes) {
+    await driftDb.routeDao.insert(route);
+    for (var tagId in allTagIds) {
+      await driftDb.routeTagDao
+          .insert(RouteTagCompanion(routeId: route.id, tagId: tagId));
+    }
+  }
+}

--- a/lib/debug/storage_inspector.dart
+++ b/lib/debug/storage_inspector.dart
@@ -1,0 +1,12 @@
+import 'package:redpoint/database/database.dart';
+import 'package:storage_inspector/storage_inspector.dart';
+import 'package:drift_local_storage_inspector/drift_local_storage_inspector.dart';
+
+Future<void> runStorageInspector(AppDatabase driftDb) async {
+  final driver = StorageServerDriver(bundleId: 'com.example.redpoint');
+  final sqlServer =
+      DriftSQLDatabaseServer(id: "1", name: "SQL Server", database: driftDb);
+
+  driver.addSQLServer(sqlServer);
+  await driver.start();
+}

--- a/lib/debug/test_data/routes.dart
+++ b/lib/debug/test_data/routes.dart
@@ -1,0 +1,49 @@
+import 'package:drift/drift.dart';
+import 'package:redpoint/database/database.dart';
+import 'package:redpoint/database/models/climb_type/climb_type.dart';
+import 'package:redpoint/database/models/grade/grade_system.dart';
+import 'package:redpoint/database/models/route/route_difficulty.dart';
+import 'package:redpoint/database/models/route/route_status.dart';
+
+List<RouteCompanion> testRoutes = [
+  RouteCompanion(
+      id: const Value(1),
+      title: const Value("Big Orange"),
+      date: Value(DateTime.parse("2019-06-26")),
+      climbTypeId: Value(ClimbTypeEnum.boulder.id),
+      gradeSystemId: Value(GradeSystemEnum.vScale.id),
+      grade: const Value("V5"),
+      status: Value(RouteStatusEnum.inProgress.id),
+      difficulty: Value(RouteDifficultyEnum.easy.id),
+      thoughts: const Value("Fun route, will get it soon.")),
+  RouteCompanion(
+      id: const Value(2),
+      title: const Value("Ka-blue-ey"),
+      date: Value(DateTime.parse("2022-06-07")),
+      climbTypeId: Value(ClimbTypeEnum.topRope.id),
+      gradeSystemId: Value(GradeSystemEnum.yds.id),
+      grade: const Value("5.11"),
+      status: Value(RouteStatusEnum.inProgress.id),
+      difficulty: Value(RouteDifficultyEnum.easy.id),
+      thoughts: const Value("Example thoughts. Hello this is a test.")),
+  RouteCompanion(
+      id: const Value(3),
+      title: const Value("Alex Handhold and the Chrisp Sharma"),
+      date: Value(DateTime.parse("2022-05-29")),
+      climbTypeId: Value(ClimbTypeEnum.lead.id),
+      gradeSystemId: Value(GradeSystemEnum.yds.id),
+      grade: const Value("5.12"),
+      status: Value(RouteStatusEnum.inProgress.id),
+      difficulty: Value(RouteDifficultyEnum.intermediate.id),
+      thoughts: const Value("Example thoughts. Hello this is a test.")),
+  RouteCompanion(
+      id: const Value(4),
+      title: const Value("This is a super long title for this climbing route"),
+      date: Value(DateTime.parse("2022-01-29")),
+      climbTypeId: Value(ClimbTypeEnum.boulder.id),
+      gradeSystemId: Value(GradeSystemEnum.vScale.id),
+      grade: const Value("V8"),
+      status: Value(RouteStatusEnum.inProgress.id),
+      difficulty: Value(RouteDifficultyEnum.easy.id),
+      thoughts: const Value("Example thoughts. Hello this is a test.")),
+];

--- a/lib/debug/test_data/tags.dart
+++ b/lib/debug/test_data/tags.dart
@@ -1,0 +1,10 @@
+import 'package:drift/drift.dart';
+import 'package:redpoint/database/database.dart';
+
+List<TagCompanion> testTags = [
+  const TagCompanion(id: Value(1), label: Value("Slopey")),
+  const TagCompanion(id: Value(2), label: Value("Slab")),
+  const TagCompanion(id: Value(3), label: Value("Dynamic")),
+  const TagCompanion(id: Value(4), label: Value("Crimpy")),
+  const TagCompanion(id: Value(5), label: Value("Comp")),
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:redpoint/debug/storage_inspector.dart';
 import 'package:redpoint/home/home_page.dart';
 import 'package:redpoint/profile/profile_page.dart';
 import 'package:redpoint/projects/projects_page.dart';
@@ -10,9 +11,6 @@ import 'package:redpoint/shared/widgets/nav/add_button.dart';
 import 'package:redpoint/shared/widgets/nav/bottom_navbar.dart';
 import 'package:redpoint/social/social_page.dart';
 
-import 'package:storage_inspector/storage_inspector.dart';
-import 'package:drift_local_storage_inspector/drift_local_storage_inspector.dart';
-
 import 'database/database.dart';
 
 void main() async {
@@ -20,14 +18,9 @@ void main() async {
 
   final driftDb = AppDatabase();
 
-  // Run storage_inspector in debug mode only
+  // Run in debug mode only
   if (kDebugMode) {
-    final driver = StorageServerDriver(bundleId: 'com.example.redpoint');
-    final sqlServer =
-        DriftSQLDatabaseServer(id: "1", name: "SQL Server", database: driftDb);
-
-    driver.addSQLServer(sqlServer);
-    await driver.start();
+    runStorageInspector(driftDb);
   }
 
   var providers = MultiProvider(


### PR DESCRIPTION
## Description

Added a new folder in lib called debug where the test data and the methods to load it live.
The idea is that we can write some data here to be pre-initialized into the database when in debug mode only.

## Ticket

RCJ-42 - [LINK](https://nmd2117.atlassian.net/browse/RCJ-42)
