### PR TITLE
RCJ-59: Changed pastDateMessage to only provide day level strings.

### DIFF
--- a/lib/shared/methods/local_date_util.dart
+++ b/lib/shared/methods/local_date_util.dart
@@ -17,12 +17,8 @@ String pastDateMessage(DateTime date) {
   DateTime now = DateTime.now();
   Duration diff = now.difference(date).abs();
 
-  if (diff.inMinutes < 1) {
-    return "A few seconds ago";
-  } else if (diff.inHours < 1) {
-    return "A few minutes ago";
-  } else if (diff.inDays < 1) {
-    return "A few hours ago";
+  if (diff.inDays < 1) {
+    return "Today";
   } else if (diff.inDays == 1) {
     return "Yesterday";
   } else if (diff.inDays < 7) {


### PR DESCRIPTION
## Description

Just fixed the pastDateMessage shared method to no longer provide "down to the minute" strings, highest level of detail is "Today" instead of "Few hours ago" etc.

Screenshot shows examples of routes logged "Today" and "Yesterday"
<img src="https://user-images.githubusercontent.com/37987430/189025327-9442f983-5ca6-4909-a3ac-3eed422ac0b7.png" alt="screenshot" width="350"/>

## Ticket

RCJ-59 - [LINK](https://nmd2117.atlassian.net/browse/RCJ-59)
